### PR TITLE
install_poppins_font

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "project-split",
       "version": "1.0.0",
       "dependencies": {
+        "@expo-google-fonts/poppins": "^0.2.2",
         "@expo/metro-config": "^0.3.18",
         "@react-navigation/bottom-tabs": "^6.3.1",
         "@react-navigation/native": "^6.0.10",
@@ -1945,6 +1946,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@expo-google-fonts/poppins": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/poppins/-/poppins-0.2.2.tgz",
+      "integrity": "sha512-x0SzC8nWTC2pInIcBDiAuMJxhoglwqCGJYMM8ylI8HKDqBxMrfRTripB3xMGo6UtzROTcL+OX1w9nEcM5FK0PQ=="
     },
     "node_modules/@expo/bunyan": {
       "version": "4.0.0",
@@ -16767,6 +16773,11 @@
           "dev": true
         }
       }
+    },
+    "@expo-google-fonts/poppins": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/poppins/-/poppins-0.2.2.tgz",
+      "integrity": "sha512-x0SzC8nWTC2pInIcBDiAuMJxhoglwqCGJYMM8ylI8HKDqBxMrfRTripB3xMGo6UtzROTcL+OX1w9nEcM5FK0PQ=="
     },
     "@expo/bunyan": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
+    "@expo-google-fonts/poppins": "^0.2.2",
     "@expo/metro-config": "^0.3.18",
     "@react-navigation/bottom-tabs": "^6.3.1",
     "@react-navigation/native": "^6.0.10",


### PR DESCRIPTION
This package is installed. 
Just import the following on top of your page to use this font:

import {
  useFonts,
  Poppins_400Regular,
  Poppins_400Regular_Italic,
} from '@expo-google-fonts/poppins';
